### PR TITLE
Allow python version 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -98,7 +99,7 @@ serve = "mkdocs serve --dev-addr localhost:8000"
 test = "mkdocs build --clean --strict"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["310", "311"]
+python = ["310", "311", "312"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ classifiers = [
 # always specify a version for each package
 # to maintain consistency
 dependencies = [
-  "qadence2-ir>=0.2",
-  "pulser>=1.1",
-  "pyqtorch",
+  "qadence2-ir~=0.2.0",
+  "pulser~=1.1.0",
+  "pyqtorch~=1.6.0",
 ]
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qadence2-platforms"
 description = "Platform-dependent engines and model to execute compiled expressions with common set of methods."
 readme = "README.md"
 version = "0.2.0"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.13"
 license = { text = "Apache 2.0" }
 keywords = ["quantum"]
 authors = [


### PR DESCRIPTION
PyQTorch is the dependency that is limiting the upperbound of supported Python versions. However, pyq does support 3.12 but not 3.13. So, proposal to change the upperbound here.