### PR TITLE
Change name in confirm deployment step in ci/cd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         timeout-minutes: 5
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          until pip download qadence2_expressions==$VERSION
+          until pip download qadence2_platforms==$VERSION
           do
             echo "Failed to download from PyPI, will wait for upload and retry."
             sleep 1


### PR DESCRIPTION
The CI/CD configuration currently checks if the deployment of a version is successful by requesting the `qadence2-expressions` package, instead of `qadence2-platforms`. This is fixed in this PR.