### PR TITLE
Fix parametric operator values as floats in `PyQTorch` backend

### DIFF
--- a/qadence2_platforms/backends/pyqtorch/compiler.py
+++ b/qadence2_platforms/backends/pyqtorch/compiler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from logging import getLogger
 
 import pyqtorch as pyq
@@ -64,10 +63,8 @@ class Compiler:
                 if len(instr.args) > 0:
                     assert len(instr.args) == 1, "More than one arg not supported"
                     (maybe_load,) = instr.args
-                    assert isinstance(maybe_load, Load), "only support load"
-                    pyq_operations.append(
-                        native_op(native_support, maybe_load.variable).to(dtype=torch.complex128)
-                    )
+                    arg = maybe_load.variable if isinstance(maybe_load, Load) else maybe_load
+                    pyq_operations.append(native_op(native_support, arg).to(dtype=torch.complex128))
 
                 else:
                     pyq_operations.append(native_op(*native_support).to(dtype=torch.complex128))

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -15,8 +15,8 @@ from qadence2_platforms.backends.fresnel1.interface import Interface as Fresnel1
 from qadence2_platforms.backends.pyqtorch.interface import Interface as PyQInterface
 
 
-N_SHOTS = 2_000
-ATOL = 0.05 * N_SHOTS
+N_SHOTS = 4_000
+ATOL = 0.06 * N_SHOTS
 
 
 def test_pyq_interface(model1: Model, pyq_interface1: PyQInterface) -> None:


### PR DESCRIPTION
Closes #18 

Currently, there's an issue when a parametric operator from `qadence2-expressions` receives a pure float number value as angle and is compiled to `pyqtorch` backend, for instance.

This PR fixes it.